### PR TITLE
Norm l1plus l2fix

### DIFF
--- a/src/functions/normL1plusL2.jl
+++ b/src/functions/normL1plusL2.jl
@@ -7,46 +7,39 @@ export NormL1plusL2
 
     NormL1plusL2(λ_1=1, λ_2=1)
 
-With two nonnegative scalar parameters λ_1 and λ_2, returns the function
+With two nonegative scalars λ_1 and λ_2, returns the function
 ```math
 f(x) = λ_1 ∑_{i=1}^{n} |x_i| + λ_2 \\sqrt{x_1^2 + … + x_n^2}.
 ```
+With nonnegative array λ_1 and nonnegative scalar λ_2, returns the function
+```math
+f(x) =  ∑_{i=1}^{n} {λ_1}_i |x_i| + λ_2 \\sqrt{x_1^2 + … + x_n^2}.
+```
 """
-struct NormL1plusL2{L <: Real, M <: Real} <: ProximableFunction
-    lambda1::L
-    lambda2::M
-    function NormL1plusL2{L, M}(lambda1::L, lambda2::M) where {L <: Real, M <: Real}
-        if lambda1 < 0 || lambda2 < 0
-            error("parameters λ_1, λ_2 must be nonnegative")
-        else
-            new(lambda1, lambda2)
-        end
-    end
+struct NormL1plusL2{L1<:NormL1, L2 <: NormL2} <: ProximableFunction
+    l1::L1
+    l2::L2
 end
 
 is_separable(f::NormL1plusL2) = false
 is_convex(f::NormL1plusL2) = true
 is_positively_homogeneous(f::NormL1plusL2) = true
 
-NormL1plusL2(lambda1::L=1, lambda2::M=1) where {L <: Real, M <: Real} = NormL1plusL2{L, M}(lambda1, lambda2)
+function NormL1plusL2(lambda1::L=1, lambda2::M=1) where {L <: Union{Real, AbstractArray}, M <: Real}
+    NormL1plusL2(NormL1(lambda1), NormL2(lambda2))
+end
 
 function (f::NormL1plusL2)(x::AbstractArray)
-    return f.lambda1 * norm(x, 1) + f.lambda2 * norm(x, 2)
+    return f.l1(x) + f.l2(x)
 end
 
 function prox!(y::AbstractArray{T}, f::NormL1plusL2, x::AbstractArray{T}, gamma::Real=1) where T <: Real
-
-    f1 = NormL1(f.lambda1)
-    f2 = NormL2(f.lambda2)
-
-    prox!(y, f1, x, gamma)
-    prox!(y, f2, y, gamma)
-
-    return f.lambda1 * norm(y, 1) + f.lambda2 * norm(y, 2)
-
+    prox!(y, f.l1, x, gamma)
+    prox!(y, f.l2, y, gamma)
+    return f(y)
 end
 
 fun_name(f::NormL1plusL2) = "L2-norm + L1-norm"
 fun_dom(f::NormL1plusL2) = "AbstractArray{Real}"
 fun_expr(f::NormL1plusL2) = "x ↦ λ_1 ||x||_1 + λ_2||x||_2"
-fun_params(f::NormL1plusL2) = "λ_1 = $(f.lambda1), λ_2 = $(f.lambda2)"
+fun_params(f::NormL1plusL2) = "λ_1 = $(f.l1.lambda), λ_2 = $(f.l2.lambda)"

--- a/test/test_equivalences.jl
+++ b/test/test_equivalences.jl
@@ -140,8 +140,6 @@ end
 
 @testset "NormL1plusL2 special case" begin
 
-x = randn(50)
-
 g = NormL2(1.)
 # λ_1 = 0
 f = NormL1plusL2(0., 1.)

--- a/test/test_normL1plusL2.jl
+++ b/test/test_normL1plusL2.jl
@@ -1,0 +1,58 @@
+
+using Random
+using ProximalOperators
+using Test
+
+
+@testset "NormL1plusL2 standard case" begin
+    f = NormL1(1.0)
+    g = NormL2(2.0)
+    fplusg = NormL1plusL2(1.0, 2.0)
+    
+    x = randn(50)
+    
+    y1, f1 = prox(f, x)
+    y2, f2 = prox(g, y1)
+    
+    y3, f3 = prox(fplusg, x)
+    
+    @test f2 ≈ f2
+    @test y2 ≈ y3
+end
+
+
+
+@testset "NormL1plusL2 norm constructor" begin
+    f = NormL1(1.0)
+    g = NormL2(2.0)
+    fplusg = NormL1plusL2(f, g)
+    
+    x = randn(50)
+    
+    y1, f1 = prox(f, x)
+    y2, f2 = prox(g, y1)
+    
+    y3, f3 = prox(fplusg, x)
+    
+    @test f2 ≈ f2
+    @test y2 ≈ y3
+end
+
+@testset "NormL1plusL2 vector case" begin
+    λ1 = abs.(randn(50))
+
+    f = NormL1(λ1)
+    g = NormL2(2.0)
+    
+    fplusg = NormL1plusL2(λ1, 2.0)
+    
+    x = randn(50)
+    
+    y1, f1 = prox(f, x)
+    y2, f2 = prox(g, y1)
+    
+    y3, f3 = prox(fplusg, x)
+    
+    @test f2 ≈ f2
+    @test y2 ≈ y3
+end

--- a/test/test_normL1plusL2.jl
+++ b/test/test_normL1plusL2.jl
@@ -16,8 +16,8 @@ using Test
     
     y3, f3 = prox(fplusg, x)
     
-    @test f2 ≈ f2
-    @test y2 ≈ y3
+    @test f3 ≈ f(y3)+g(y3)
+    @test y3 ≈ y2
 end
 
 
@@ -34,8 +34,8 @@ end
     
     y3, f3 = prox(fplusg, x)
     
-    @test f2 ≈ f2
-    @test y2 ≈ y3
+    @test f3 ≈ f(y3)+g(y3)
+    @test y3 ≈ y2
 end
 
 @testset "NormL1plusL2 vector case" begin
@@ -43,7 +43,7 @@ end
 
     f = NormL1(λ1)
     g = NormL2(2.0)
-    
+
     fplusg = NormL1plusL2(λ1, 2.0)
     
     x = randn(50)
@@ -53,6 +53,6 @@ end
     
     y3, f3 = prox(fplusg, x)
     
-    @test f2 ≈ f2
-    @test y2 ≈ y3
+    @test f3 ≈ f(y3)+g(y3)
+    @test y3 ≈ y2
 end


### PR DESCRIPTION
I didn't like that we created the L1 and L2 norms in the `prox!` call because it forces us to recheck that the parameters are positive every time. I rewrote the struct to contain the norm functions instead, and allowed `lambda1` to be a vector. I think the code looks slightly better this way.
This PR also defer almost all computations to existing implementations.